### PR TITLE
Memory leaks fixes and sd2-image deinitialization for tutorials 1 - 11

### DIFF
--- a/05-optimized-surface-loading-and-soft-stretching.lisp
+++ b/05-optimized-surface-loading-and-soft-stretching.lisp
@@ -22,7 +22,8 @@
   (let ((image (sdl2:load-bmp pathname)))
     (if (autowrap:wrapper-null-p image)
         (error "cannot load image ~a (check that file exists)" pathname)
-        (sdl2:convert-surface-format image pixel-format))))
+        (prog1 (sdl2:convert-surface-format image pixel-format)
+          (sdl2:free-surface image)))))
 
 (defun run ()
   (with-window-surface (window screen-surface)

--- a/07-texture-loading-and-rendering.lisp
+++ b/07-texture-loading-and-rendering.lisp
@@ -37,4 +37,5 @@
                (sdl2:render-present renderer)))
 
       ;; clean up
-      (sdl2:destroy-texture texture))))
+      (sdl2:destroy-texture texture)
+      (sdl2-image:quit))))

--- a/08-geometry-rendering.lisp
+++ b/08-geometry-rendering.lisp
@@ -24,7 +24,7 @@
       (:quit () t)
       (:idle ()
              ;; Clear screen
-             (sdl2:set-render-draw-color renderer #xFF #xFF #xFF #xFF)
+             (sdl2:set-render-draw-color renderer 255 255 255 255)
              (sdl2:render-clear renderer)
 
              ;; Render red filled quad
@@ -32,7 +32,7 @@
                                           (/ *screen-height* 4)
                                           (/ *screen-width* 2)
                                           (/ *screen-height* 2)))
-               (sdl2:set-render-draw-color renderer #xFF #x00 #x00 #xFF)
+               (sdl2:set-render-draw-color renderer 255 0 0 255)
                (sdl2:render-fill-rect renderer fill-rect))
 
              ;; Render green outlined quad
@@ -40,11 +40,11 @@
                                              (round (/ *screen-height* 8))
                                              (round (* 2/3 *screen-width*))
                                              (round (* 2/3 *screen-height*))))
-               (sdl2:set-render-draw-color renderer #x00 #xFF #x00 #xFF)
+               (sdl2:set-render-draw-color renderer 0 255 0 255)
                (sdl2:render-draw-rect renderer outline-rect))
 
              ;; Draw blue horizontal line
-             (sdl2:set-render-draw-color renderer #x00 #x00 #xFF #xFF)
+             (sdl2:set-render-draw-color renderer 0 0 255 255)
              (sdl2:render-draw-line renderer
                                     0
                                     (/ *screen-height* 2)
@@ -52,9 +52,12 @@
                                     (/ *screen-height* 2))
 
              ;; Draw vertical line of yellow dots
-             (sdl2:set-render-draw-color renderer #xFF #xFF #x00 #xFF)
+             (sdl2:set-render-draw-color renderer 255 255 0 255)
              (loop for i from 0 below *screen-height* by 4
                    do (sdl2::render-draw-point renderer (/ *screen-width* 2) i))
 
              ;; Update screen
-             (sdl2:render-present renderer)))))
+             (sdl2:render-present renderer)))
+
+    ;; Clean up
+    (sdl2-image:quit)))

--- a/08-geometry-rendering.lisp
+++ b/08-geometry-rendering.lisp
@@ -24,7 +24,7 @@
       (:quit () t)
       (:idle ()
              ;; Clear screen
-             (sdl2:set-render-draw-color renderer 255 255 255 255)
+             (sdl2:set-render-draw-color renderer #xFF #xFF #xFF #xFF)
              (sdl2:render-clear renderer)
 
              ;; Render red filled quad
@@ -32,7 +32,7 @@
                                           (/ *screen-height* 4)
                                           (/ *screen-width* 2)
                                           (/ *screen-height* 2)))
-               (sdl2:set-render-draw-color renderer 255 0 0 255)
+               (sdl2:set-render-draw-color renderer #xFF #x00 #x00 #xFF)
                (sdl2:render-fill-rect renderer fill-rect))
 
              ;; Render green outlined quad
@@ -44,7 +44,7 @@
                (sdl2:render-draw-rect renderer outline-rect))
 
              ;; Draw blue horizontal line
-             (sdl2:set-render-draw-color renderer 0 0 255 255)
+             (sdl2:set-render-draw-color renderer #x00 #x00 #xFF #xFF)
              (sdl2:render-draw-line renderer
                                     0
                                     (/ *screen-height* 2)
@@ -52,7 +52,7 @@
                                     (/ *screen-height* 2))
 
              ;; Draw vertical line of yellow dots
-             (sdl2:set-render-draw-color renderer 255 255 0 255)
+             (sdl2:set-render-draw-color renderer #xFF #xFF #x00 #xFF)
              (loop for i from 0 below *screen-height* by 4
                    do (sdl2::render-draw-point renderer (/ *screen-width* 2) i))
 

--- a/08-geometry-rendering.lisp
+++ b/08-geometry-rendering.lisp
@@ -40,7 +40,7 @@
                                              (round (/ *screen-height* 8))
                                              (round (* 2/3 *screen-width*))
                                              (round (* 2/3 *screen-height*))))
-               (sdl2:set-render-draw-color renderer 0 255 0 255)
+               (sdl2:set-render-draw-color renderer #x00 #xFF #x00 #xFF)
                (sdl2:render-draw-rect renderer outline-rect))
 
              ;; Draw blue horizontal line

--- a/09-the-viewport.lisp
+++ b/09-the-viewport.lisp
@@ -58,5 +58,7 @@
                  (sdl2:render-copy renderer texture))
 
                (sdl2:render-present renderer)))
+
       ;; cleanup
-      (sdl2:destroy-texture texture))))
+      (sdl2:destroy-texture texture)
+      (sdl2-image:quit))))

--- a/10-color-keying.lisp
+++ b/10-color-keying.lisp
@@ -68,4 +68,5 @@
                (sdl2:render-present renderer)))
       ;; clean up
       (free-tex background-tex)
-      (free-tex player-tex))))
+      (free-tex player-tex)
+      (sdl2-image:quit))))

--- a/11-clip-rendering-and-sprite-sheets.lisp
+++ b/11-clip-rendering-and-sprite-sheets.lisp
@@ -14,13 +14,17 @@
     :initform (error "Must supply a renderer"))
    (width
     :accessor tex-width
-    :initform 0 )
+    :initform 0)
    (height
     :accessor tex-height
     :initform 0)
    (texture
     :accessor tex-texture
     :initform nil)))
+
+(defun free-tex (tex)
+  (with-slots (texture) tex
+    (sdl2:destroy-texture texture)))
 
 (defun load-texture-from-file (renderer pathname)
   (let ((tex (make-instance 'tex :renderer renderer)))
@@ -88,4 +92,8 @@
                        (- *screen-height* (sdl2:rect-height bottom-right))
                        :clip bottom-right)
 
-               (sdl2:render-present renderer))))))
+               (sdl2:render-present renderer)))
+
+      ;; Clean up
+      (free-tex spritesheet-tex)
+      (sdl2-image:quit))))


### PR DESCRIPTION
Just completed 11th tutorial, so this PR for 1 - 11 tutorials only.

05 -> sdl2:free-surface used on image loaded initially
11 -> free-tex method added and used on texture class instance

07, 08, 09, 10, 11 -> since we're initializing sdl2-image manually we need to use sdl2-image:quit manually too