### PR TITLE
Tutorials 12-16 fixes

### DIFF
--- a/12-color-modulation.lisp
+++ b/12-color-modulation.lisp
@@ -14,13 +14,17 @@
     :initform (error "Must supply a renderer"))
    (width
     :accessor tex-width
-    :initform 0 )
+    :initform 0)
    (height
     :accessor tex-height
     :initform 0)
    (texture
     :accessor tex-texture
     :initform nil)))
+
+(defun free-tex (tex)
+  (with-slots (texture) tex
+    (sdl2:destroy-texture texture)))
 
 (defun load-texture-from-file (renderer filename)
   (let ((tex (make-instance 'tex :renderer renderer)))
@@ -30,7 +34,8 @@
         (setf height (sdl2:surface-height surface))
         (sdl2:set-color-key surface :true (sdl2:map-rgb (sdl2:surface-format surface)
                                                         0 #xFF #xFF))
-        (setf texture (sdl2:create-texture-from-surface renderer surface))))
+        (setf texture (sdl2:create-texture-from-surface renderer surface))
+        (sdl2:free-surface surface)))
     tex))
 
 (defun set-color (tex r g b)
@@ -89,4 +94,8 @@
                (sdl2:render-clear renderer)
                (set-color texture r g b)
                (render texture 0 0)
-               (sdl2:render-present renderer))))))
+               (sdl2:render-present renderer)))
+
+      ;; Clean up
+      (free-tex texture)
+      (sdl2-image:quit))))

--- a/13-alpha-blending.lisp
+++ b/13-alpha-blending.lisp
@@ -14,13 +14,17 @@
     :initform (error "Must supply a renderer"))
    (width
     :accessor tex-width
-    :initform 0 )
+    :initform 0)
    (height
     :accessor tex-height
     :initform 0)
    (texture
     :accessor tex-texture
     :initform nil)))
+
+(defun free-tex (tex)
+  (with-slots (texture) tex
+    (sdl2:destroy-texture texture)))
 
 (defun load-texture-from-file (renderer filename)
   (let ((tex (make-instance 'tex :renderer renderer)))
@@ -30,7 +34,8 @@
         (setf height (sdl2:surface-height surface))
         (sdl2:set-color-key surface :true (sdl2:map-rgb (sdl2:surface-format surface)
                                                         0 #xFF #xFF))
-        (setf texture (sdl2:create-texture-from-surface renderer surface))))
+        (setf texture (sdl2:create-texture-from-surface renderer surface))
+        (sdl2:free-surface surface)))
     tex))
 
 (defun set-color (tex r g b)
@@ -91,4 +96,9 @@
                (render bg-texture 0 0)
                (set-alpha modulated-texture alpha)
                (render modulated-texture 0 0)
-               (sdl2:render-present renderer))))))
+               (sdl2:render-present renderer)))
+
+      ;; Clean up
+      (free-tex bg-texture)
+      (free-tex modulated-texture)
+      (sdl2-image:quit))))

--- a/14-animated-sprites-and-vsync.lisp
+++ b/14-animated-sprites-and-vsync.lisp
@@ -14,13 +14,17 @@
     :initform (error "Must supply a renderer"))
    (width
     :accessor tex-width
-    :initform 0 )
+    :initform 0)
    (height
     :accessor tex-height
     :initform 0)
    (texture
     :accessor tex-texture
     :initform nil)))
+
+(defun free-tex (tex)
+  (with-slots (texture) tex
+    (sdl2:destroy-texture texture)))
 
 (defun load-texture-from-file (renderer filename)
   (let ((tex (make-instance 'tex :renderer renderer)))
@@ -30,7 +34,8 @@
         (setf height (sdl2:surface-height surface))
         (sdl2:set-color-key surface :true (sdl2:map-rgb (sdl2:surface-format surface)
                                                         0 #xFF #xFF))
-        (setf texture (sdl2:create-texture-from-surface renderer surface))))
+        (setf texture (sdl2:create-texture-from-surface renderer surface))
+        (sdl2:free-surface surface)))
     tex))
 
 (defun set-color (tex r g b)
@@ -97,4 +102,8 @@
                  (incf current-sprite-frame)
                  (when (>= current-sprite-frame sprite-frames)
                    (setf current-sprite-frame 0))
-                 (setf (sdl2:rect-x clip) (* current-sprite-frame (sdl2:rect-width clip)))))))))
+                 (setf (sdl2:rect-x clip) (* current-sprite-frame (sdl2:rect-width clip))))))
+
+      ;; Clean up
+      (free-tex spritesheet-tex)
+      (sdl2-image:quit))))

--- a/16-true-type-fonts.lisp
+++ b/16-true-type-fonts.lisp
@@ -16,7 +16,7 @@
     :initform (error "Must supply a renderer"))
    (width
     :accessor tex-width
-    :initform 0 )
+    :initform 0)
    (height
     :accessor tex-height
     :initform 0)
@@ -36,7 +36,8 @@
         (setf height (sdl2:surface-height surface))
         (sdl2:set-color-key surface :true (sdl2:map-rgb (sdl2:surface-format surface)
                                                         0 #xFF #xFF))
-        (setf texture (sdl2:create-texture-from-surface renderer surface))))
+        (setf texture (sdl2:create-texture-from-surface renderer surface))
+        (sdl2:free-surface surface)))
     tex))
 
 (defun load-texture-from-text (renderer text)
@@ -45,7 +46,8 @@
       (let ((surface (sdl2-ttf:render-text-solid *font* text 0 0 0 0)))
         (setf width (sdl2:surface-width surface))
         (setf height (sdl2:surface-height surface))
-        (setf texture (sdl2:create-texture-from-surface renderer surface))))
+        (setf texture (sdl2:create-texture-from-surface renderer surface))
+        (sdl2:free-surface surface)))
     tex))
 
 (defun set-color (tex r g b)
@@ -71,7 +73,7 @@
                         :w *screen-width*
                         :h *screen-height*
                         :flags '(:shown))
-       (sdl2:with-renderer (,renderer ,window :index -1 :flags '(:accelerated))
+       (sdl2:with-renderer (,renderer ,window :index -1 :flags '(:accelerated :presentvsync))
          ,@body))))
 
 (defun run ()
@@ -89,7 +91,8 @@
                        (round (/ (- *screen-width* (tex-width texture)) 2))
                        (round (/ (- *screen-height* (tex-height texture)) 2)))
                (sdl2:render-present renderer)))
+
       ;; clean up
-      (free-tex texture))
-    (sdl2-ttf:quit)
-    (sdl2-image:quit)))
+      (free-tex texture)
+      (sdl2-ttf:quit)
+      (sdl2-image:quit))))

--- a/16-true-type-fonts.lisp
+++ b/16-true-type-fonts.lisp
@@ -94,5 +94,7 @@
 
       ;; clean up
       (free-tex texture)
+      (sdl2-ttf:close-font *font*)
+      (setf *font* nil)
       (sdl2-ttf:quit)
       (sdl2-image:quit))))


### PR DESCRIPTION
Possible memory leaks fixes for tutorials 12 - 16.

12 - 16 -> same as before (free-tex, destroy temporary surface after image load, sdl2-image:quit)

15 and 16 -> not a leak fix, but i'm too lazy to make additional PR for this. In lazy foo's original tutorial 14 we can find such statement: "For this (and future tutorials), we want to use Vertical Sync." So, from now on user expects to see renderer's ":presentvsync" flag in each tutorial.

16 -> closing font before sdl2-ttf:quit